### PR TITLE
updated greenlet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ elasticsearch==7.11.0
 flask==1.1.2
 gevent-websocket==0.10.1
 gevent==21.1.2
-greenlet==1.0.0 ; platform_python_implementation == 'CPython'
+greenlet==1.1.0 ; platform_python_implementation == 'CPython'
 idna==2.10
 importlib-metadata==3.7.2 ; python_version < '3.8'
 itsdangerous==1.1.0


### PR DESCRIPTION
Updated greenlet version to 1.1.0 as 1.0.0 was causing errors while installing requirements. the issue is described [here](https://github.com/mitre/cascade-server/issues/17)